### PR TITLE
Tensorflow 2.3.0 + general improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,57 +2,88 @@ ARG BUILD_FROM
 FROM $BUILD_FROM
 
 ARG BUILD_ARCH
-ARG TENSORFLOW_VERSION=2.2.0
-ARG BAZEL_VERSION=2.0.0
+ARG TENSORFLOW_VERSION=2.3.0
+ARG BAZEL_VERSION=3.5.0
+ARG SENTENCEPIECE_VERSION=0.1.92
+ARG TENSORFLOW_ADDONS_VERSION=0.11.2
 
 WORKDIR /usr/src
-COPY *.patch ./
 RUN apk add --no-cache \
-        freetype \
-        libpng \
-        libjpeg-turbo \
-        musl \
-    && apk add --no-cache --virtual=.build-dependencies \
-        git \
-        cmake \
-        build-base \
-        curl \
-        linux-headers \
-        openjdk11 \
-        zip \
         autoconf \
         automake \
-        libtool \
-        sed \
+        build-base \
+        cmake \
+        curl \
+        cython \
+        freetype \
+        freetype-dev \
+        gfortran \
+        git \
         hdf5-dev \
+        lapack-dev \
         libexecinfo-dev \
         libexecinfo-static \
-        freetype-dev \
+        libjpeg-turbo \
         libjpeg-turbo-dev \
+        libpng \
         libpng-dev \
+        libtool \
+        linux-headers \
+        musl \
+        openblas-dev \
+        openjdk11 \
+        patchelf \
+        pkgconfig \
+        rsync \
+        sed \
+        zip \
     \
-    && rm -rf /usr/lib/jvm/java-11-openjdk/jre \
-    && export JAVA_HOME="/usr/lib/jvm/java-11-openjdk" \
-    \
-    && cd /usr/src \
+    && rm -rf /usr/lib/jvm/java-11-openjdk/jre
+
+ENV JAVA_HOME="/usr/lib/jvm/java-11-openjdk"
+
+RUN pip3 install \
+        --no-cache-dir \
+        --find-links "https://wheels.home-assistant.io/alpine-$(cut -d '.' -f 1-2 < /etc/alpine-release)/${BUILD_ARCH}/" \
+        wheel \
+        six \
+        numpy \
+        auditwheel
+
+RUN cd /usr/src \
+    && git clone -b v${SENTENCEPIECE_VERSION} --depth 1 https://github.com/google/sentencepiece \
+    && mkdir -p sentencepiece/build \
+    && cd /usr/src/sentencepiece/build \
+    && cmake .. \
+    && make -j $(nproc) \
+    && make install \
+    && cd ../python \
+    && pip3 wheel \
+        --find-links "https://wheels.home-assistant.io/alpine-$(cut -d '.' -f 1-2 < /etc/alpine-release)/${BUILD_ARCH}/" \
+        . \
+    && export LD_LIBRARY_PATH=/usr/local/lib \
+    && auditwheel repair sentencepiece-${SENTENCEPIECE_VERSION}-cp38-cp38-linux_x86_64.whl \
+        --no-update-tags \
+        -w /usr/src/wheels
+
+RUN cd /usr/src \
     && curl -SLO \
         https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-$BAZEL_VERSION-dist.zip \
     && mkdir bazel-$BAZEL_VERSION \
     && unzip -qd bazel-$BAZEL_VERSION bazel-$BAZEL_VERSION-dist.zip \
     && cd /usr/src/bazel-$BAZEL_VERSION \
     && EXTRA_BAZEL_ARGS=--host_javabase=@local_jdk//:jdk ./compile.sh \
-    && cp -p output/bazel /usr/bin/ \
-    \
-    && cd /usr/src \
-    && pip3 install --no-cache-dir \
-        --find-links "https://wheels.home-assistant.io/alpine-$(cut -d '.' -f 1-2 < /etc/alpine-release)/${BUILD_ARCH}/" \
-        wheel six numpy \
+    && cp -p output/bazel /usr/bin/
+    
+COPY *.patch ./
+RUN cd /usr/src \
     && pip3 install --no-cache-dir \
         --no-deps keras_applications==1.0.6 keras_preprocessing==1.0.5 \
     && git clone -b v${TENSORFLOW_VERSION} --depth 1 https://github.com/tensorflow/tensorflow \
     && for i in /usr/src/*.patch; do \
-        patch -d /usr/src/tensorflow -p 1 < "${i}"; done \
-    && cd /usr/src/tensorflow \
+        patch -d /usr/src/tensorflow -p 1 < "${i}"; done
+
+RUN cd /usr/src/tensorflow \
     && sed -i -e '/HAVE_MALLINFO/d' third_party/llvm/llvm.bzl \
     && PYTHON_BIN_PATH=/usr/local/bin/python3 PYTHON_LIB_PATH=/usr/local/lib/python3.8/site-packages \
         CC_OPT_FLAGS="-mtune=generic" TF_NEED_JEMALLOC=1 TF_CUDA_CLANG=0 TF_NEED_GCP=0 TF_NEED_HDFS=0 \
@@ -64,16 +95,33 @@ RUN apk add --no-cache \
         --cxxopt="-D_GLIBCXX_USE_CXX11_ABI=0" \
         --linkopt=-lexecinfo --host_linkopt=-lexecinfo \
         --noincompatible_strict_action_env \
-        //tensorflow/tools/pip_package:build_pip_package \
-    && ./bazel-bin/tensorflow/tools/pip_package/build_pip_package /usr/src/wheels \
-    \
-    && cd /usr/src/wheels \
+        //tensorflow/tools/pip_package:build_pip_package
+
+RUN cd /usr/src/tensorflow \
+    && ./bazel-bin/tensorflow/tools/pip_package/build_pip_package /usr/src/wheels 
+
+RUN cd /usr/src/wheels \
     && pip3 wheel \
         --wheel-dir /usr/src/wheels/ \
         --find-links "https://wheels.home-assistant.io/alpine-$(cut -d '.' -f 1-2 < /etc/alpine-release)/${BUILD_ARCH}/" \
-        tensorflow-${TENSORFLOW_VERSION}-*.whl \
-    && rm -rf /usr/src/tensorflow \
-    && rm -f /usr/bin/bazel \
-    && rm -rf /usr/src/bazel-$BAZEL_VERSION \
-    && rm -rf /usr/src/hdf5-$HDF5_VERSION \
-    && apk del .build-dependencies
+        tensorflow-${TENSORFLOW_VERSION}-*.whl
+
+RUN cd /usr/src/wheels \
+    && pip3 install \
+        --find-links "https://wheels.home-assistant.io/alpine-$(cut -d '.' -f 1-2 < /etc/alpine-release)/${BUILD_ARCH}/" \
+        tensorflow-${TENSORFLOW_VERSION}-*.whl
+
+RUN cd /usr/src \
+    && git clone -b v${TENSORFLOW_ADDONS_VERSION} --depth 1 https://github.com/tensorflow/addons
+
+RUN cd /usr/src/addons \
+    && python3 ./configure.py \
+    && bazel build --enable_runfiles build_pip_pkg \
+    && bazel-bin/build_pip_pkg  /usr/src/wheels
+
+RUN cd /usr/src/wheels \
+    && pip3 wheel \
+        --wheel-dir /usr/src/wheels/ \
+        --find-links "https://wheels.home-assistant.io/alpine-$(cut -d '.' -f 1-2 < /etc/alpine-release)/${BUILD_ARCH}/" \
+        *.whl \
+        tf-models-official

--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # TensorFlow for Home Assistant
-Build wheels for TensorFlow and Home Assistant
+
+Build wheels for TensorFlow and Home Assistant.
+
+## Manually building
+
+A manual build can take a long time (4-5 hours or longer is normal).
+
+To manually build the wheels using this Docker image:
+
+```bash
+docker build  --build-arg BUILD_FROM=homeassistant/amd64-base-python:3.8-alpine3.12 --build-arg BUILD_ARCH=amd64 --tag tensorflow:amd64 .
+```
+
+If the build was successful, the wheel files can be extracted from the resulting
+Docker images like so:
+
+```bash
+mkdir wheels
+docker create --name tensorflow tensorflow:amd64 bash -c sleep 90000
+docker cp "tensorflow:/usr/src/wheels/." wheels
+docker rm tensorflow
+```
+
+The `wheels` folder now contains all the Python wheels.
+
+## Caveats
+
+Using a lot of resources to speed up the build usually leads to failed builds.
+For example, building with 32Gb mem and 16 AMD Ryzen 7 cores just fails faster.
+
+Tests showed running with 16Gb of memory with 4 cores, does the job relatively
+fast and stable.


### PR DESCRIPTION
This PR bumps the wheels-tensorflow to Tensorflow 2.3.0

Compared to the current version in this repository it adds:

- Some small instructions in the README
- Split into multiple Docker commands/layers, allowing for resuming builds when manually debugging or building (leverage Docker' layer caching)
- Adds Sentencepiece
- Adds Tensorflow add-ons
- Adds Tensorflow models
- Bumps Bazel to 3.5.0
- Bumps Tensorflow to 2.3.0

Superseeds #6 
Supports https://github.com/home-assistant/core/pull/39673